### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com//.git"
+      "url": "https://github.com/NeblioTeam/neblio-api-lib-php.git"
     }
   ],
   "require": {


### PR DESCRIPTION
Missing vendor/package name in composer.json file (probably configuration in Swagger)